### PR TITLE
Make application more configurable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+NOVEM_API_URL=/api
+NOVEM_PORT=8080
+
+# Uncomment this variable to proxy requests to the Novem API to avoid CORS
+# issues for local development. Note: this only works if the API URL configured
+# with $NOVEM_API_URL is only a URL path, not a full URL.
+# NOVEM_API_PROXY_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ jspm_packages
 .idea
 
 .DS_Store
+
+# Local environment files
+/.env*
+!/.env.sample

--- a/README.md
+++ b/README.md
@@ -1,14 +1,64 @@
-# novemlabfront
-Front app for transmedia project novemlab https://github.com/ghiringh/transmedia
+# Novem Lab
+
+Frontend application for the transmedia project novemlab:
+https://github.com/ghiringh/transmedia
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Installation](#installation)
+- [Development](#development)
+- [Production](#production)
+- [Configuration](#configuration)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Installation
-```
-git clone repo
-npm install
+
+```bash
+git clone https://github.com/MediaComem/novemlabfront.git
+cd novemlabfront
+npm ci
 ```
 
-###### run with nodemon
-> npm run dev
+## Development
 
-###### serve the app
-> npm start
+Create a local environment file:
+
+```
+cp .env.sample .env
+```
+
+> If you are also running the Novem API locally and are not using a reverse
+> proxy, you can configure a proxy to avoid CORS issues. See
+> [Configuration](#configuration) below.
+
+Run the application in development mode with live code reload:
+
+```
+npm run dev
+```
+
+Visit http://localhost:8080 (if you are using the default port).
+
+## Production
+
+Run the application in production mode:
+
+```
+npm start
+```
+
+## Configuration
+
+Environment variable   | Default value | Description
+:--------------------- | :------------ | :----------------------------------------------------------------------------
+`$NOVEM_API_URL`       | `/api`        | URL where the Novem API can be reached.
+`$NOVEM_API_PROXY_URL` | -             | If specified, requests to the Novem API will be proxied to avoid CORS issues.
+`$NOVEM_PORT`          | `8080`        | Port on which the application's HTTP server will listen to.
+
+> See [`config.js`][./config.js] for more information.
+
+In development, environment variables can be set by creating an `.env` file (see
+[`.env.sample`](./.env.sample)).

--- a/app.js
+++ b/app.js
@@ -1,24 +1,24 @@
-var express = require('express');
-var path = require('path');
-var favicon = require('serve-favicon');
-var logger = require('morgan');
-var cookieParser = require('cookie-parser');
-var bodyParser = require('body-parser');
-var index = require('./routes/index');
-var niveau1 = require('./routes/niveau1');
-var niveau2 = require('./routes/niveau2');
-var niveau3 = require('./routes/niveau3');
-var niveau4 = require('./routes/niveau4');
-var niveau5 = require('./routes/niveau5');
-var niveau6 = require('./routes/niveau6');
-var niveau7 = require('./routes/niveau7');
-var niveauF = require('./routes/niveauF');
-var end = require('./routes/end');
-var save = require('./routes/save');
-var profile = require('./routes/profile');
-//var Chart = require('chart.js');
-var app = express();
-var proxy = require('express-http-proxy');
+const express = require('express');
+const path = require('path');
+const favicon = require('serve-favicon');
+const logger = require('morgan');
+const cookieParser = require('cookie-parser');
+const bodyParser = require('body-parser');
+const index = require('./routes/index');
+const niveau1 = require('./routes/niveau1');
+const niveau2 = require('./routes/niveau2');
+const niveau3 = require('./routes/niveau3');
+const niveau4 = require('./routes/niveau4');
+const niveau5 = require('./routes/niveau5');
+const niveau6 = require('./routes/niveau6');
+const niveau7 = require('./routes/niveau7');
+const niveauF = require('./routes/niveauF');
+const end = require('./routes/end');
+const save = require('./routes/save');
+const profile = require('./routes/profile');
+const { configureApiProxy, getLocals } = require('./utils');
+
+const app = express();
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -44,12 +44,12 @@ app.use('/nF', niveauF);
 app.use('/save', save);
 app.use('/profile', profile);
 app.use('/end', end);
-app.use('/api-proxy', proxy(process.env.PROXY_URL || 'localhost:3000'));
 
+configureApiProxy(app);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {
-    var err = new Error('Not Found');
+    const err = new Error('Not Found');
     err.status = 404;
     next(err);
 });
@@ -62,7 +62,7 @@ app.use(function(err, req, res, next) {
 
     // render the error page
     res.status(err.status || 500);
-    res.render('error');
+    res.render('error', getLocals());
 });
 
 module.exports = app;

--- a/bin/www
+++ b/bin/www
@@ -4,22 +4,23 @@
  * Module dependencies.
  */
 
-var app = require('../app');
-var debug = require('debug')('front-novemlab:server');
-var http = require('http');
+const app = require('../app');
+const config = require('../config');
+const debug = require('debug')('front-novemlab:server');
+const http = require('http');
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '8080');
+const port = normalizePort(config.port);
 app.set('port', port);
 
 /**
  * Create HTTP server.
  */
 
-var server = http.createServer(app);
+const server = http.createServer(app);
 
 /**
  * Listen on provided port, on all network interfaces.
@@ -34,7 +35,7 @@ server.on('listening', onListening);
  */
 
 function normalizePort(val) {
-  var port = parseInt(val, 10);
+  const port = parseInt(val, 10);
 
   if (isNaN(port)) {
     // named pipe
@@ -58,7 +59,7 @@ function onError(error) {
     throw error;
   }
 
-  var bind = typeof port === 'string'
+  const bind = typeof port === 'string'
     ? 'Pipe ' + port
     : 'Port ' + port;
 
@@ -82,8 +83,8 @@ function onError(error) {
  */
 
 function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string'
+  const addr = server.address();
+  const bind = typeof addr === 'string'
     ? 'pipe ' + addr
     : 'port ' + addr.port;
   debug('Listening on ' + bind);

--- a/config.js
+++ b/config.js
@@ -1,0 +1,37 @@
+try {
+  require('dotenv').config();
+} catch (err) {
+  // Ignore missing dotenv in production.
+}
+
+/**
+ * URL where the Novem API can be reached. This can be only a URL path when
+ * deployed behind a reverse proxy or with a local proxy (see `apiProxyUrl`
+ * below).
+ */
+exports.apiUrl = process.env.NOVEM_API_URL || '/api';
+
+/**
+ * You can proxy requests to the Novem API for local development. If an API
+ * proxy URL is specified, requests to the configured API URL will be proxied to
+ * avoid CORS issues.
+ *
+ * Note the following caveats:
+ *
+ * * The configured API URL must be a URL path and not a full URL (e.g. `/api`
+ *   and not `http://localhost:3000/api`).
+ * * The configured URL path is not included in the proxied request.
+ *
+ *   For example, if `apiUrl` is set to `/api` and `apiProxyUrl` is set to
+ *   http://localhost:3000, the request will be proxied to
+ *   http://localhost:3000, not http://localhost:3000/api.
+ *
+ *   To keep the `/api` in the proxied request, include it in `apiProxyUrl`:
+ *   http://localhost:3000/api.
+ */
+exports.apiProxyUrl = process.env.NOVEM_API_PROXY_URL;
+
+/**
+ * Port on which the application's HTTP server will listen to.
+ */
+exports.port = process.env.NOVEM_PORT || process.env.PORT || 8080;

--- a/package-lock.json
+++ b/package-lock.json
@@ -468,6 +468,12 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www",
-    "dev": "nodemon -e js,jade,css ./bin/www"
+    "dev": "nodemon -e js,jade,css ./bin/www",
+    "start": "node ./bin/www"
   },
   "dependencies": {
     "angular": "^1.7.9",
@@ -19,5 +19,8 @@
     "nodemon": "^2.0.2",
     "pug": "^2.0.4",
     "serve-favicon": "~2.5.0"
+  },
+  "devDependencies": {
+    "dotenv": "^8.2.0"
   }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -3,7 +3,7 @@ angular.module('novemlab', [
     'ui.router'
 ]);
 
-
 angular.module('novemlab')
-    .constant('apiUrl', '/api-proxy')
+    // Retrieve the API URL from the DOM.
+    .constant('apiUrl', $('meta[name="apiUrl"]').attr('content') || '/api')
 ;

--- a/routes/end.js
+++ b/routes/end.js
@@ -1,11 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
-router.route('/').get
-(function(req, res) {
-        res.status(200).render('end');
+router.route('/').get(function(req, res) {
+    res.status(200).render('end', getLocals());
 });
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,9 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-    res.render('intro');
+    res.render('intro', getLocals());
 });
+
 module.exports = router;

--- a/routes/niveau1.js
+++ b/routes/niveau1.js
@@ -1,9 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-    res.render('niveau1');
+    res.render('niveau1', getLocals());
 });
+
 module.exports = router;

--- a/routes/niveau2.js
+++ b/routes/niveau2.js
@@ -1,9 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-    res.render('niveau2');
+    res.render('niveau2', getLocals());
 });
+
 module.exports = router;

--- a/routes/niveau3.js
+++ b/routes/niveau3.js
@@ -1,9 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-    res.render('niveau3');
+    res.render('niveau3', getLocals());
 });
+
 module.exports = router;

--- a/routes/niveau4.js
+++ b/routes/niveau4.js
@@ -1,9 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-    res.render('niveau4');
+    res.render('niveau4', getLocals());
 });
+
 module.exports = router;

--- a/routes/niveau5.js
+++ b/routes/niveau5.js
@@ -1,9 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-    res.render('niveau5');
+    res.render('niveau5', getLocals());
 });
+
 module.exports = router;

--- a/routes/niveau6.js
+++ b/routes/niveau6.js
@@ -1,9 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-    res.render('niveau6');
+    res.render('niveau6', getLocals());
 });
+
 module.exports = router;

--- a/routes/niveau7.js
+++ b/routes/niveau7.js
@@ -1,9 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-    res.render('niveau7');
+    res.render('niveau7', getLocals());
 });
+
 module.exports = router;

--- a/routes/niveauF.js
+++ b/routes/niveauF.js
@@ -1,12 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
-router.route('/:id').get
-(function(req, res) {
-    console.log(req.params.id);
-        res.status(200).render('niveau'+req.params.id);
+router.route('/:id').get(function(req, res) {
+    res.status(200).render('niveau'+req.params.id, getLocals());
 });
 
 module.exports = router;

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -1,12 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
-router.route('/').get
-(function(req, res) {
-    console.log(req.params.id);
-        res.status(200).render('profile');
+router.route('/').get(function(req, res) {
+    res.status(200).render('profile', getLocals());
 });
 
 module.exports = router;

--- a/routes/save.js
+++ b/routes/save.js
@@ -1,12 +1,11 @@
-var express = require('express');
-var router = express.Router();
-var path = require('path');
+const express = require('express');
+const { getLocals } = require('../utils');
+
+const router = express.Router();
 
 /* GET home page. */
-router.route('/').get
-(function(req, res) {
-    console.log(req.params.id);
-        res.status(200).render('save');
+router.route('/').get(function(req, res) {
+    res.status(200).render('save', getLocals());
 });
 
 module.exports = router;

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,50 @@
+const debug = require('debug')('front-novemlab:utils');
+const proxy = require('express-http-proxy');
+
+const { apiUrl, apiProxyUrl } = require('./config');
+
+/**
+ * Optionally adds a proxy to the Novem API to the application. This is done
+ * only if a proxy URL is explicitly configured.
+ */
+exports.configureApiProxy = function(app) {
+  if (!apiProxyUrl) {
+    // Do not set up a proxy if not explicitly configured.
+    return;
+  } else if (!apiUrl.match(/^\/[^/]/)) {
+    // Require the API URL to be only a path with a leading slash, and not a
+    // full URL.
+    throw new Error(`To enable proxying with $NOVEM_API_PROXY_URL, the API URL configured with $NOVEM_API_URL (currently "${apiUrl}") must be a path, not a full URL`);
+  }
+
+  // Get the proxy URL's path.
+  const apiBasePath = new URL(apiProxyUrl).pathname;
+
+  // Get the proxy URL without the path, query or hash.
+  const apiProxyUrlBase = new URL(apiProxyUrl);
+  apiProxyUrlBase.hash = '';
+  apiProxyUrlBase.search = '';
+  apiProxyUrlBase.pathname = '';
+
+  // Set up the proxy.
+  app.use(apiUrl, proxy(apiProxyUrlBase.toString(), {
+    // Keep the configured path.
+    proxyReqPathResolver: req => `${apiBasePath}/${req.url}`
+  }));
+
+  debug(`Proxying ${apiUrl} to ${apiProxyUrlBase.toString()} with API base path ${apiBasePath}`);
+};
+
+/**
+ * Creates an object of local variables to render a view, with the following
+ * variables included by default:
+ *
+ * * `apiUrl` - The URL to the Novem API (injected into a `meta` tag in the
+ *   default layout).
+ */
+exports.getLocals = function(extraLocals) {
+  return {
+    apiUrl,
+    ...extraLocals
+  };
+};

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -3,6 +3,7 @@ html(ng-app="novemlab")
   head
     title= title
     meta(name='viewport', content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no')
+    meta(name='apiUrl', content=apiUrl)
     link(rel='stylesheet', href='/stylesheets/style.css')
     link(rel='stylesheet', href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css")
     link(rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous")


### PR DESCRIPTION
* Add dotenv for easy local configuration.
* Make the API proxy configurable.
* Disable the API proxy by default (as it can be superfluous in
  production when already deploying behind a reverse proxy).